### PR TITLE
Add ClickUp title enforcement (CU-36ew98y)

### DIFF
--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -1,0 +1,8 @@
+{
+  "title": [
+    {
+      "pattern": "[A-Za-z].*\\s\\(CU-[0-9A-Za-z]{3,10}\\)",
+      "message": "A ClickUp story is required in the pull request title. Ex: Add X button to Y page (CU-123)"
+    }
+  ]
+}


### PR DESCRIPTION
### Description

Added a config file for the PRLint Reloaded Github App, which enforces that every PR has a ClickUp task ID in the PR title. The format is: `Add X to Y (CU-a1b2c3d)`, where `a1b2c3d` is the ClickUp task ID.

### Other changes

N/A

### Tested

TODO

### Related issues

N/A

### Backwards compatibility

All new PRs will require a ClickUp task ID in the title.
