### PR TITLE
Allow multiple SQL queries to run in one `runQuery` (CU-2pxh3br)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ tmp
 
 # User data
 *.sqlite
+
+# IDE
+/.idea

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -9,5 +9,11 @@ export interface Database {
 
   exportDatabase(): Uint8Array;
 
-  runQuery(query: string): any;
+  runQuery(query: string): QueryResult[];
+}
+
+export interface QueryResult {
+  queryString?: string;
+  queryResult?: any;
+  error?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 import { zipToSQLiteInstance } from "./services/zipToSQLite.js";
 import { validateEmailIntegrationZip } from "./services/zipValidator.js";
+import { extractTablesFromSqlQuery } from "./utils/extractTablesFromSqlQuery.js";
 import { loadZipFile } from "./utils/loadZipFile.js";
 import { stripZipFiles } from "./utils/stripZipFiles.js";
 
 export {
+  extractTablesFromSqlQuery,
   loadZipFile,
   stripZipFiles,
   validateEmailIntegrationZip,

--- a/src/models/table/integerTableValue.ts
+++ b/src/models/table/integerTableValue.ts
@@ -1,9 +1,9 @@
 import { ColumnTableValue } from "./columnTableValue.js";
 
 export class IntegerTableValue extends ColumnTableValue {
-  constructor(value: string) {
-    super(value);
+  constructor(value: string | number) {
+    super(`${value}`);
     this.type = "integer";
-    this.value = Number.parseInt(value, 10);
+    this.value = typeof value === "number" ? value : Number.parseInt(value, 10);
   }
 }

--- a/src/utils/extractTablesFromSqlQuery.ts
+++ b/src/utils/extractTablesFromSqlQuery.ts
@@ -1,0 +1,13 @@
+/**
+ * Extract the table names from an SQL query
+ * @param query Raw SQL query string
+ * @returns set of table names in the query
+ */
+const extractTablesFromSqlQuery = (query: string): Set<string> => {
+  const tableNames = query
+    .toLowerCase()
+    .match(/(?<= (from|join) \s*)([a-z0-9-_]+)/gm);
+  return new Set<string>(tableNames);
+};
+
+export { extractTablesFromSqlQuery };

--- a/test/database/sqliteDatabase.test.ts
+++ b/test/database/sqliteDatabase.test.ts
@@ -1,0 +1,56 @@
+import { QueryResult } from "../../src/database/database";
+import { SQLiteDatabase } from "../../src/database/sqliteDatabase";
+import {
+  IntegerTableValue,
+  Table,
+  TextTableValue,
+} from "../../src/models/table";
+
+describe("SQLite Database", () => {
+  const database = new SQLiteDatabase();
+
+  beforeAll(async () => {
+    const personalInformation = new Table("personal_information");
+    personalInformation.rows.push({
+      first_name: new TextTableValue("John"),
+      last_name: new TextTableValue("Doe"),
+      age: new IntegerTableValue(25),
+    });
+    personalInformation.rows.push({
+      first_name: new TextTableValue("Jane"),
+      last_name: new TextTableValue("Smith"),
+      age: new IntegerTableValue(30),
+    });
+
+    await database.initialize();
+    database.createTable(personalInformation);
+  });
+
+  describe("runQuery", () => {
+    test("it should run a single query", async () => {
+      const query: QueryResult[] = database.runQuery(
+        "select * from personal_information"
+      );
+      expect(query.length).toEqual(1);
+      expect(query[0].queryResult[0].values.length).toEqual(2);
+    });
+
+    test("it should run multiple queries", async () => {
+      const query: QueryResult[] = database.runQuery(
+        `select * from personal_information;
+         select AVG(age) from personal_information;
+         select SUM(age) from personal_information;`
+      );
+      expect(query.length).toEqual(3);
+    });
+
+    test("it should run partial queries when error occurs", async () => {
+      const query: QueryResult[] = database.runQuery(
+        `select * from personal_information;
+         select * from personal_information where non_existing_column = NULL;
+         select * from non_existing_table;`
+      );
+      expect(query.length).toEqual(2);
+    });
+  });
+});

--- a/test/utils/extractTablesFromSqlQuery.test.ts
+++ b/test/utils/extractTablesFromSqlQuery.test.ts
@@ -1,0 +1,14 @@
+import { extractTablesFromSqlQuery } from "../../src/utils/extractTablesFromSqlQuery.js";
+
+describe("extractPermissionsFromQuery", () => {
+  it("extractPermissionsFromQuery", () => {
+    const permissions = extractTablesFromSqlQuery(
+      `SELECT * FROM personal_interests;
+       SELECT * FROM non_existing_table;
+       SELECT * FROM ads_interests
+            INNER JOIN instagram_interests ON ads_interests.ad_id = instagram_interests.id
+            INNER JOIN (SELECT * FROM personal_interests) AS pi ON ads_interests.id = pi.id;`
+    );
+    expect(permissions.size).toEqual(4);
+  });
+});


### PR DESCRIPTION
### Description

This PR introduces the following changes:
- Allow multiple queries to be run in `database.runQuery`, ex: 
   ```
    const database = await zipToSQLiteInstance("instagram", file);
    const results = database.runQuery("SELECT * FROM personal_information; SELECT AVG(age) FROM personal_information;");
   ```
- Provide helper util to extract table names from a query.
   ```
    const permissions = extractTablesFromSqlQuery(
      `SELECT * FROM personal_interests;
       SELECT * FROM non_existing_table;
       SELECT * FROM ads_interests
            INNER JOIN instagram_interests ON ads_interests.ad_id = instagram_interests.id
            INNER JOIN (SELECT * FROM personal_interests) AS pi ON ads_interests.id = pi.id;`
    ); 
    // ['personal_interests', 'non_existing_table', 'ads_interests', 'instagram_interests']
   ```

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
