### PR TITLE
Disable Web Workers in ZipJS to fix Webkit support (CU-39nt0qq)

### DIFF
--- a/src/extractor/fileExtractor.ts
+++ b/src/extractor/fileExtractor.ts
@@ -70,6 +70,10 @@ export class FileExtractor {
    * @param zipEntry
    */
   async loadFileContents(zipEntry: zip.ZipEntry) {
+    // TODO: Remove later
+    zip.configure({
+      useWebWorkers: false,
+    });
     this.zipEntry = zipEntry;
     this.mimeType = zip.getMimeType(zipEntry.name);
     this.fileContents = await this.zipEntry.data.getData(

--- a/src/extractor/fileExtractor.ts
+++ b/src/extractor/fileExtractor.ts
@@ -70,10 +70,6 @@ export class FileExtractor {
    * @param zipEntry
    */
   async loadFileContents(zipEntry: zip.ZipEntry) {
-    // TODO: Remove later
-    zip.configure({
-      useWebWorkers: false,
-    });
     this.zipEntry = zipEntry;
     this.mimeType = zip.getMimeType(zipEntry.name);
     this.fileContents = await this.zipEntry.data.getData(

--- a/src/services/zipToSQLite.ts
+++ b/src/services/zipToSQLite.ts
@@ -14,9 +14,10 @@ Extractors.register();
  */
 const zipToSQLiteInstance = async (
   serviceName: string,
-  file: File
+  file: File,
+  useWebWorkers = true
 ): Promise<Database> => {
-  const zipFile = await loadZipFile(file);
+  const zipFile = await loadZipFile(file, useWebWorkers);
   const database = new SQLiteDatabase();
   await database.initialize();
 

--- a/src/utils/extractTablesFromSqlQuery.ts
+++ b/src/utils/extractTablesFromSqlQuery.ts
@@ -6,7 +6,8 @@
 const extractTablesFromSqlQuery = (query: string): Set<string> => {
   const tableNames = query
     .toLowerCase()
-    .match(/(?<= (from|join) \s*)([a-z0-9-_]+)/gm);
+    .match(/(?: (from|join) \s*)([a-z0-9-_]+)/gm)
+    .map((match) => match.replace(" from ", "").replace(" join ", ""));
   return new Set<string>(tableNames);
 };
 

--- a/src/utils/loadZipFile.ts
+++ b/src/utils/loadZipFile.ts
@@ -1,8 +1,11 @@
 import { ZipFile } from "./zipFile.js";
 
-const loadZipFile = async (file: File): Promise<ZipFile> => {
+const loadZipFile = async (
+  file: File,
+  useWebWorkers = true
+): Promise<ZipFile> => {
   const zipFile = new ZipFile(file);
-  await zipFile.importFileSystem({ filenameEncoding: "utf-8" });
+  await zipFile.importFileSystem({ filenameEncoding: "utf-8", useWebWorkers });
   return zipFile;
 };
 

--- a/test/services/zipToSQLite.test.ts
+++ b/test/services/zipToSQLite.test.ts
@@ -18,7 +18,7 @@ describe("services/zipExporter", () => {
   it("zipToSQLiteInstance() saves an HTML export as sqlite file", async () => {
     deleteFile("instagram_html_1.sqlite");
     const file = await loadTestFile("instagram_html_1.zip");
-    const database = await zipToSQLiteInstance("instagram", file);
+    const database = await zipToSQLiteInstance("instagram", file, false);
     saveSqliteDump(database.exportDatabase(), "instagram_html_1.sqlite");
     expect(fileExists("instagram_html_1.sqlite")).toBeTruthy();
   });
@@ -26,7 +26,7 @@ describe("services/zipExporter", () => {
   it("zipToSQLiteInstance() saves a JSON export as sqlite file", async () => {
     deleteFile("instagram_json_1.sqlite");
     const file = await loadTestFile("instagram_json_1.zip");
-    const database = await zipToSQLiteInstance("instagram", file);
+    const database = await zipToSQLiteInstance("instagram", file, false);
     saveSqliteDump(database.exportDatabase(), "instagram_json_1.sqlite");
     expect(fileExists("instagram_json_1.sqlite")).toBeTruthy();
   });


### PR DESCRIPTION
### Description

Fixes all webkit browsers (`safari` on desktop, `chrome/safari/firefox/etc` on iOS)