### PR TITLE
FIX Amazon Order - Extracting empty data

### DIFF
--- a/src/extractor/amazonOrders/csv/ordersCsv.ts
+++ b/src/extractor/amazonOrders/csv/ordersCsv.ts
@@ -7,10 +7,14 @@ const extractPrice = (price: string) =>
 
 class OrdersCsv extends CsvExtractor {
   async process() {
+    if (this.fileContents.includes("No data found for this time period")) {
+      return;
+    }
+
     await this.parse();
 
     if (this.csvDocument) {
-      const mappedRow = this.csvDocument.map(
+      const mappedRows = this.csvDocument.map(
         (order: any) =>
           new Orders({
             orderDate: order["order date"],
@@ -55,7 +59,7 @@ class OrdersCsv extends CsvExtractor {
           })
       );
 
-      this.table.rows.push(...mappedRow);
+      this.table.rows.push(...mappedRows);
     }
   }
 }


### PR DESCRIPTION
### Description

Just a quick fix of Amazon extractor loading correctly a file with no data. Will look into handling errors and empty data and general solution for such cases next week. Just committing this as I promised to have this done last week.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
