### PR TITLE
FIX TEST Multiple files cross-contamination extraction

### DIFF
--- a/src/extractor/fileExtractor.ts
+++ b/src/extractor/fileExtractor.ts
@@ -90,4 +90,22 @@ export class FileExtractor {
       database.createTable(this.serviceName, this.table);
     }
   }
+
+  /**
+   * Used mainly for testing. When multiple files for the same service are
+   * processed needs to dump the extractors data between different files.
+   * @param serviceName
+   */
+  static dumpExtractorData(serviceName: string) {
+    if (!FileExtractor.registeredExtractors[serviceName]) {
+      throw new Error(`Extractors for service ${serviceName} do not exist`);
+    }
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const extractorEntry of FileExtractor.registeredExtractors[
+      serviceName
+    ]) {
+      extractorEntry.extractor.table.rows = [];
+    }
+  }
 }


### PR DESCRIPTION
### Description

The reason for the bug was:
1. The extractors are loaded into a static array (see `fileExtractor.ts` lines `7-16`)
2. These are only once initialized and then are loaded when they are appropriate for a file.
3. The extractors contain their own data - `.table.rows`. This doesn't get cleared, therefore if multiple files for the same extractor type are used, they all feed into the same array and the data is shared.

Current suggested solution:
1. Zip test files for the same service type are run sequentially, so that one file uses the extractor data, after it is finished the data gets cleared and another file gets extracted.
2. I created a static method `dumpExtractorData` in `FileExtractor`. This empties all the extractors' `.table.rows`.
At the moment this might be enough unless we want to have some sort of data separation in this sense on the client side. Do we expect users to provide multiple zip files for the same extractor type? And if we do, do we want to keep the data in separate sqlite databases?